### PR TITLE
Added the img width limit to message styles

### DIFF
--- a/Format/Resources/Text/Formatter.css
+++ b/Format/Resources/Text/Formatter.css
@@ -367,6 +367,9 @@
   font-family: Verdana, Geneva, sans-serif;
   color: #003000;
 }
+.m img {
+    max-width:100%;
+}
 .m img.i,
 .m img.t,
 .m img.s,


### PR DESCRIPTION
max-width: 100% should fix the too-wide images within the user messages, leaving all the icons, etc unaffected. 