### PR TITLE
Support size for the IMG tag

### DIFF
--- a/Format/FormatterImageHelper.cs
+++ b/Format/FormatterImageHelper.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using System.Text;
+
+namespace Rsdn.Framework.Formatting
+{
+    public class FormatterImageHelper
+    {
+        public static bool IsValidAttribute(string name)
+        {
+            return Regex.IsMatch(name, "width|height", RegexOptions.IgnoreCase);
+        }
+
+        public static bool IsValidValue(string val)
+        {
+            return Regex.IsMatch(val, @"^\d+(px|pt|mm|cm|in|em|rem|vh|vw|%)?$", RegexOptions.IgnoreCase);
+        }
+
+        public static IEnumerable<Tuple<string, string>> GetImageAttributes(string attributes)
+        {
+            yield return Tuple.Create("border", "0");
+
+            var matches = Regex.Matches(attributes, @"(?<name>[\w]+\s*)=\s*(?<value>([\w]+|""[\w]+""|'[\w]+'))");
+            foreach (var match in matches.Cast<Match>())
+            {
+                var name = match.Groups["name"].Value.Trim(' ');
+                var value = match.Groups["value"].Value.Trim('\'', '\"');
+
+                if (IsValidAttribute(name) && IsValidValue(value))
+                {
+                    yield return Tuple.Create(name, value);
+                }
+            }
+        }
+
+        public static string RenderImgAttributes(IEnumerable<Tuple<string, string>> attributes)
+        {
+            return string.Join(" ", attributes.Select(a => $"{a.Item1}='{a.Item2}'"));
+        }
+    }
+}

--- a/Format/FormatterImageHelper.cs
+++ b/Format/FormatterImageHelper.cs
@@ -6,38 +6,74 @@ using System.Text;
 
 namespace Rsdn.Framework.Formatting
 {
-    public class FormatterImageHelper
-    {
-        public static bool IsValidAttribute(string name)
-        {
-            return Regex.IsMatch(name, "width|height", RegexOptions.IgnoreCase);
-        }
+	/// <summary>
+	/// Helper class for image attributes formatting.
+	/// </summary>
+	public static class FormatterImageHelper
+	{
+		public struct ImgAttribute
+		{
+			public string Name;
+			public string Value;
+		}
 
-        public static bool IsValidValue(string val)
-        {
-            return Regex.IsMatch(val, @"^\d+(px|pt|mm|cm|in|em|rem|vh|vw|%)?$", RegexOptions.IgnoreCase);
-        }
+		private static readonly Regex _attributesRegex =
+			new Regex(@"(?<name>[\w]+\s*)=\s*(?<value>([\w]+|""[\w]+""|'[\w]+'))",
+						RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
-        public static IEnumerable<Tuple<string, string>> GetImageAttributes(string attributes)
-        {
-            yield return Tuple.Create("border", "0");
+		private static readonly Regex _attrNameRegex =
+			new Regex(@"width|height",
+						RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
-            var matches = Regex.Matches(attributes, @"(?<name>[\w]+\s*)=\s*(?<value>([\w]+|""[\w]+""|'[\w]+'))");
-            foreach (var match in matches.Cast<Match>())
-            {
-                var name = match.Groups["name"].Value.Trim(' ');
-                var value = match.Groups["value"].Value.Trim('\'', '\"');
+		private static readonly Regex _valueRegex =
+			new Regex(@"^\d+(px|pt|mm|cm|in|em|rem|vh|vw|%)?$",
+						RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
-                if (IsValidAttribute(name) && IsValidValue(value))
-                {
-                    yield return Tuple.Create(name, value);
-                }
-            }
-        }
+		/// <summary>
+		/// Only width and height attributes are allowed.
+		/// </summary>
+		public static bool IsValidAttribute(string name)
+		{
+			return _attrNameRegex.IsMatch(name);
+		}
 
-        public static string RenderImgAttributes(IEnumerable<Tuple<string, string>> attributes)
-        {
-            return string.Join(" ", attributes.Select(a => $"{a.Item1}='{a.Item2}'"));
-        }
-    }
+		/// <summary>
+		/// restrict values to numbers with basic units
+		/// </summary>
+		public static bool IsValidValue(string val)
+		{
+			return _valueRegex.IsMatch(val);
+		}
+
+		/// <summary>
+		/// collect image attributes from string
+		/// </summary>
+		public static IEnumerable<ImgAttribute> GetImageAttributes(string attributes)
+		{
+			yield return new ImgAttribute { Name = "border", Value = "0" };
+
+			if (string.IsNullOrEmpty(attributes))
+				yield break;
+
+			var matches = _attributesRegex.Matches(attributes);
+			foreach (var match in matches.Cast<Match>())
+			{
+				var name = match.Groups["name"].Value.Trim(' ');
+				var value = match.Groups["value"].Value.Trim('\'', '\"');
+
+				if (IsValidAttribute(name) && IsValidValue(value))
+				{
+					yield return new ImgAttribute { Name = name, Value = value };
+				}
+			}
+		}
+
+		/// <summary>
+		/// render collected image attributes back as string
+		/// </summary>
+		public static string RenderImgAttributes(IEnumerable<ImgAttribute> attributes)
+		{
+			return string.Join(" ", attributes.Select(a => $"{a.Name}='{a.Value}'"));
+		}
+	}
 }

--- a/Format/TextFormatter.cs
+++ b/Format/TextFormatter.cs
@@ -229,7 +229,7 @@ namespace Rsdn.Framework.Formatting
 		/// [img] тэг. С защитой от javascript.
 		/// </summary>
 		private static readonly Regex _imgTagRegex =
-			new Regex(@"(?i)(?<!\[)\[img\]\s*(?!(javascript|vbscript|jscript):)(?<url>.*?)\s*\[[\\/]img\]",
+			new Regex(@"(?i)(?<!\[)\[img(?<attributes>[^]]*?)\]\s*(?!(javascript|vbscript|jscript):)(?<url>.*?)\s*\[[\\/]img\]",
 								RegexOptions.Compiled);
 
 		/// <summary>
@@ -239,7 +239,13 @@ namespace Rsdn.Framework.Formatting
 		/// <returns>Formatted image value</returns>
 		public virtual string ProcessImages(Match image)
 		{
-			return $"<img border='0' src='{image.Groups["url"].Value.EncodeAgainstXSS()}' />";
+			var src = image.Groups["url"].Value.EncodeAgainstXSS();
+
+            var attributes = image.Groups["attributes"].Value;
+			var parsed = FormatterImageHelper.GetImageAttributes(attributes);
+			var combined = FormatterImageHelper.RenderImgAttributes(parsed);
+
+            return $"<img {combined} src='{src}' />";
 		}
 		#endregion
 

--- a/Format/TextFormatter.cs
+++ b/Format/TextFormatter.cs
@@ -241,11 +241,11 @@ namespace Rsdn.Framework.Formatting
 		{
 			var src = image.Groups["url"].Value.EncodeAgainstXSS();
 
-            var attributes = image.Groups["attributes"].Value;
+			var attributes = image.Groups["attributes"].Value;
 			var parsed = FormatterImageHelper.GetImageAttributes(attributes);
 			var combined = FormatterImageHelper.RenderImgAttributes(parsed);
 
-            return $"<img {combined} src='{src}' />";
+			return $"<img {combined} src='{src}' />";
 		}
 		#endregion
 

--- a/Rsdn.Framework.Formatting-Tests/FormatterTestCaseSource.cs
+++ b/Rsdn.Framework.Formatting-Tests/FormatterTestCaseSource.cs
@@ -15,7 +15,8 @@ namespace Rsdn.Framework.Formatting.Tests
 	{
 		public IEnumerator GetEnumerator()
 		{
-			yield return GetTestCaseData("Nitra");
+            yield return GetTestCaseData("Img");
+            yield return GetTestCaseData("Nitra");
 			yield return GetTestCaseData("Nemerle");
 			yield return GetTestCaseData("Cpp");
 			yield return GetTestCaseData("Cut");
@@ -35,7 +36,7 @@ namespace Rsdn.Framework.Formatting.Tests
 			yield return GetTestCaseData("Urls");
 			yield return GetTestCaseData("XSS");
 			yield return GetTestCaseData("LinkJSInjection");
-		}
+        }
 
 		private static TestCaseData GetTestCaseData(string name)
 		{

--- a/Rsdn.Framework.Formatting-Tests/FormatterTestCaseSource.cs
+++ b/Rsdn.Framework.Formatting-Tests/FormatterTestCaseSource.cs
@@ -15,8 +15,8 @@ namespace Rsdn.Framework.Formatting.Tests
 	{
 		public IEnumerator GetEnumerator()
 		{
-            yield return GetTestCaseData("Img");
-            yield return GetTestCaseData("Nitra");
+			yield return GetTestCaseData("Img");
+			yield return GetTestCaseData("Nitra");
 			yield return GetTestCaseData("Nemerle");
 			yield return GetTestCaseData("Cpp");
 			yield return GetTestCaseData("Cut");
@@ -36,7 +36,7 @@ namespace Rsdn.Framework.Formatting.Tests
 			yield return GetTestCaseData("Urls");
 			yield return GetTestCaseData("XSS");
 			yield return GetTestCaseData("LinkJSInjection");
-        }
+		}
 
 		private static TestCaseData GetTestCaseData(string name)
 		{
@@ -59,7 +59,7 @@ namespace Rsdn.Framework.Formatting.Tests
 			var testCaseData = new TestCaseData(original);
 
 			testCaseData.SetName(name);
-			testCaseData.Returns(gold.Split(new[] {'\r', '\n'}, StringSplitOptions.RemoveEmptyEntries));
+			testCaseData.Returns(gold.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries));
 
 			return testCaseData;
 		}

--- a/Rsdn.Framework.Formatting-Tests/TestData/Img.gold
+++ b/Rsdn.Framework.Formatting-Tests/TestData/Img.gold
@@ -1,0 +1,12 @@
+<html>
+	<body>
+<img border='0' src='http://foo.jpg' /><br />
+<img border='0' width='100' src='http://foo.jpg' /><br />
+<img border='0' width='100' src='http://foo.jpg' /><br />
+<img border='0' width='100px' src='http://foo.jpg' /><br />
+<img border='0' width='100px' src='http://foo.jpg' /><br />
+<img border='0' width='10cm' src='http://foo.jpg' /><br />
+<img border='0' width='10px' height='20px' src='http://foo.jpg' /><br />
+<img border='0' src='http://foo.jpg' />
+	</body>
+</html>

--- a/Rsdn.Framework.Formatting-Tests/TestData/Img.txt
+++ b/Rsdn.Framework.Formatting-Tests/TestData/Img.txt
@@ -1,0 +1,8 @@
+﻿[img]http://foo.jpg[/img]
+[img width=100]http://foo.jpg[/img]
+[img width = 100 ]http://foo.jpg[/img]
+[img width=100px]http://foo.jpg[/img]
+[img width="100px"]http://foo.jpg[/img]
+[img width='10cm']http://foo.jpg[/img]
+[img width=10px height=20px]http://foo.jpg[/img]
+[img unsupported="ignore"]http://foo.jpg[/img]


### PR DESCRIPTION
Support image width and height in `[img]` tag.
```
[img width=100]http://foo.jpg[/img]
[img width=10px height=20px]http://foo.jpg[/img]
```
All other attributes in the [img] and tag are ignored for now if present (just to be on the safe side).
Test set updated.

@andrewvk Please review if it makes sense when you have time