### PR TITLE
allow to specify large/small size for img tags (alternative to width/…

### DIFF
--- a/Format/Resources/Text/Formatter.css
+++ b/Format/Resources/Text/Formatter.css
@@ -370,6 +370,12 @@
 .m img {
     max-width:100%;
 }
+.m img.small {
+    max-width: 20vw;
+}
+.m img.large {
+    max-width: 90vw;
+}
 .m img.i,
 .m img.t,
 .m img.s,

--- a/Format/TextFormatter.cs
+++ b/Format/TextFormatter.cs
@@ -232,6 +232,8 @@ namespace Rsdn.Framework.Formatting
 			new Regex(@"(?i)(?<!\[)\[img\s*(?<decorator>\w+)?\s*\]\s*(?!(javascript|vbscript|jscript):)(?<url>.*?)\s*\[[\\/]img\]",
 								RegexOptions.Compiled);
 
+		private static readonly Regex _validImgTagDecoratorRegex = new Regex(@"large|small", RegexOptions.Compiled);
+
 		/// <summary>
 		/// Process RSDN IMG tag
 		/// </summary>
@@ -242,7 +244,7 @@ namespace Rsdn.Framework.Formatting
 			var src = image.Groups["url"].Value.EncodeAgainstXSS();
 			var decorator = image.Groups["decorator"].Value;
 
-			if (!string.IsNullOrEmpty(decorator))
+			if (_validImgTagDecoratorRegex.IsMatch(decorator))
 				return $"<img border='0' class='{decorator}' src='{src}' />";
 			else
 				return $"<img border='0' src='{src}' />";

--- a/Format/TextFormatter.cs
+++ b/Format/TextFormatter.cs
@@ -229,7 +229,7 @@ namespace Rsdn.Framework.Formatting
 		/// [img] тэг. С защитой от javascript.
 		/// </summary>
 		private static readonly Regex _imgTagRegex =
-			new Regex(@"(?i)(?<!\[)\[img\]\s*(?!(javascript|vbscript|jscript):)(?<url>.*?)\s*\[[\\/]img\]",
+			new Regex(@"(?i)(?<!\[)\[img\s*(?<decorator>\w+)?\s*\]\s*(?!(javascript|vbscript|jscript):)(?<url>.*?)\s*\[[\\/]img\]",
 								RegexOptions.Compiled);
 
 		/// <summary>
@@ -239,7 +239,13 @@ namespace Rsdn.Framework.Formatting
 		/// <returns>Formatted image value</returns>
 		public virtual string ProcessImages(Match image)
 		{
-			return $"<img border='0' src='{image.Groups["url"].Value.EncodeAgainstXSS()}' />";
+			var src = image.Groups["url"].Value.EncodeAgainstXSS();
+			var decorator = image.Groups["decorator"].Value;
+
+			if (!string.IsNullOrEmpty(decorator))
+				return $"<img border='0' class='{decorator}' src='{src}' />";
+			else
+				return $"<img border='0' src='{src}' />";
 		}
 		#endregion
 

--- a/Rsdn.Framework.Formatting-Tests/FormatterTestCaseSource.cs
+++ b/Rsdn.Framework.Formatting-Tests/FormatterTestCaseSource.cs
@@ -15,6 +15,7 @@ namespace Rsdn.Framework.Formatting.Tests
 	{
 		public IEnumerator GetEnumerator()
 		{
+			yield return GetTestCaseData("Img");
 			yield return GetTestCaseData("Nitra");
 			yield return GetTestCaseData("Nemerle");
 			yield return GetTestCaseData("Cpp");

--- a/Rsdn.Framework.Formatting-Tests/TestData/Img.gold
+++ b/Rsdn.Framework.Formatting-Tests/TestData/Img.gold
@@ -1,0 +1,7 @@
+<html>
+	<body>
+<img border='0' src='http://foo.jpg' /><br />
+<img border='0' class='small' src='http://foo.jpg' /><br />
+<img border='0' class='large' src='http://foo.jpg' />
+	</body>
+</html>

--- a/Rsdn.Framework.Formatting-Tests/TestData/Img.txt
+++ b/Rsdn.Framework.Formatting-Tests/TestData/Img.txt
@@ -1,0 +1,3 @@
+﻿[img]http://foo.jpg[/img]
+[img small]http://foo.jpg[/img]
+[img large]http://foo.jpg[/img]


### PR DESCRIPTION
Alternative option for small/large css class for image support
(i.e. to #9, @andrewvk please cancel that one if you decide to pick this one)
```
[img]http://foo.jpg[/img]
[img small]http://foo.jpg[/img]
[img large]http://foo.jpg[/img]
```
`<img border='0' src='http://foo.jpg' />`
`<img border='0' class='small' src='http://foo.jpg' />`
`<img border='0' class='large' src='http://foo.jpg' />`
```