### PR TITLE
Img small / large options improvements

### DIFF
--- a/Format/Resources/Text/Formatter.css
+++ b/Format/Resources/Text/Formatter.css
@@ -371,10 +371,10 @@
     max-width:100%;
 }
 .m img.small {
-    max-width: 20vw;
+    max-width: 10vw;
 }
 .m img.large {
-    max-width: 90vw;
+    max-width: 50vw;
 }
 .m img.i,
 .m img.t,

--- a/Format/TextFormatter.cs
+++ b/Format/TextFormatter.cs
@@ -229,7 +229,7 @@ namespace Rsdn.Framework.Formatting
 		/// [img] тэг. С защитой от javascript.
 		/// </summary>
 		private static readonly Regex _imgTagRegex =
-			new Regex(@"(?i)(?<!\[)\[img\s*(?<decorator>\w+)?\s*\]\s*(?!(javascript|vbscript|jscript):)(?<url>.*?)\s*\[[\\/]img\]",
+			new Regex(@"(?i)(?<!\[)\[img\s*(=?)\s*(?<decorator>\w+)?\s*\]\s*(?!(javascript|vbscript|jscript):)(?<url>.*?)\s*\[[\\/]img\]",
 								RegexOptions.Compiled);
 
 		private static readonly Regex _validImgTagDecoratorRegex = new Regex(@"large|small", RegexOptions.Compiled);

--- a/Rsdn.Framework.Formatting-Tests/TestData/Img.gold
+++ b/Rsdn.Framework.Formatting-Tests/TestData/Img.gold
@@ -2,6 +2,10 @@
 	<body>
 <img border='0' src='http://foo.jpg' /><br />
 <img border='0' class='small' src='http://foo.jpg' /><br />
-<img border='0' class='large' src='http://foo.jpg' />
+<img border='0' class='large' src='http://foo.jpg' /><br />
+<img border='0' class='small' src='http://foo.jpg' /><br />
+<img border='0' class='large' src='http://foo.jpg' /><br />
+<img border='0' src='http://foo.jpg' /><br />
+<img border='0' src='http://foo.jpg' />
 	</body>
 </html>

--- a/Rsdn.Framework.Formatting-Tests/TestData/Img.txt
+++ b/Rsdn.Framework.Formatting-Tests/TestData/Img.txt
@@ -1,3 +1,7 @@
 ﻿[img]http://foo.jpg[/img]
+[img=small]http://foo.jpg[/img]
+[img=large]http://foo.jpg[/img]
 [img small]http://foo.jpg[/img]
 [img large]http://foo.jpg[/img]
+[img=sometext]http://foo.jpg[/img]
+[img sometext]http://foo.jpg[/img]


### PR DESCRIPTION
Allow "=" sign (change syntax) `[img=small]...[/img]` 
Change size (small=10vw, large=50vw)